### PR TITLE
Fix updateShot to persist zero values

### DIFF
--- a/controller/__tests__/shotController.test.js
+++ b/controller/__tests__/shotController.test.js
@@ -113,6 +113,62 @@ describe("shotController session statistics", () => {
     expect(updatedSession.minScore).toBe(10);
   });
 
+  it("allows updating shot values to zero", async () => {
+    const baseParams = {
+      sessionId: session._id.toString(),
+      userId: userId.toString(),
+    };
+
+    const initialTimestamp = new Date("2024-01-01T00:00:00Z");
+
+    const addRes = createMockResponse();
+    await addShot(
+      {
+        params: baseParams,
+        body: {
+          score: 5,
+          positionX: 4,
+          positionY: 6,
+          timestamp: initialTimestamp,
+        },
+      },
+      addRes,
+    );
+
+    const shot = await Shot.findOne({ sessionId: session._id });
+
+    const zeroTimestamp = new Date(0);
+
+    const updateRes = createMockResponse();
+    await updateShot(
+      {
+        params: {
+          shotId: shot._id.toString(),
+          userId: userId.toString(),
+        },
+        body: {
+          score: 0,
+          positionX: 0,
+          positionY: 0,
+          timestamp: zeroTimestamp,
+        },
+      },
+      updateRes,
+    );
+
+    const updatedShot = await Shot.findById(shot._id);
+    expect(updatedShot.score).toBe(0);
+    expect(updatedShot.positionX).toBe(0);
+    expect(updatedShot.positionY).toBe(0);
+    expect(updatedShot.timestamp.getTime()).toBe(zeroTimestamp.getTime());
+
+    const updatedSession = await Session.findById(session._id);
+    expect(updatedSession.totalShots).toBe(1);
+    expect(updatedSession.averageScore).toBe(0);
+    expect(updatedSession.maxScore).toBe(0);
+    expect(updatedSession.minScore).toBe(0);
+  });
+
   it("recalculates statistics when deleting shots", async () => {
     const baseParams = {
       sessionId: session._id.toString(),

--- a/controller/shotController.js
+++ b/controller/shotController.js
@@ -126,10 +126,18 @@ export const updateShot = async (req, res) => {
         .json({ error: "Unauthorized to update this shot" });
     }
 
-    shot.score = req.body.score || shot.score;
-    shot.positionX = req.body.positionX || shot.positionX;
-    shot.positionY = req.body.positionY || shot.positionY;
-    shot.timestamp = req.body.timestamp || shot.timestamp;
+    if (req.body.score !== undefined) {
+      shot.score = req.body.score;
+    }
+    if (req.body.positionX !== undefined) {
+      shot.positionX = req.body.positionX;
+    }
+    if (req.body.positionY !== undefined) {
+      shot.positionY = req.body.positionY;
+    }
+    if (req.body.timestamp !== undefined) {
+      shot.timestamp = req.body.timestamp;
+    }
 
     await shot.save();
 


### PR DESCRIPTION
## Summary
- update the shot update logic to only skip undefined fields so zero values persist
- add a regression test confirming score, position, and timestamp can be updated to zero while stats refresh

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e7beda30832a8580118f732bf64d