### PR TITLE
Update session populateShots to return populate promise

### DIFF
--- a/model/__tests__/sessionModel.test.js
+++ b/model/__tests__/sessionModel.test.js
@@ -1,0 +1,58 @@
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import Session from "../session.js";
+import Shot from "../shot.js";
+
+jest.setTimeout(60000);
+
+describe("Session model populateShots", () => {
+  let mongoServer;
+  let userId;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+    userId = new mongoose.Types.ObjectId();
+  });
+
+  beforeEach(async () => {
+    await Session.deleteMany({});
+    await Shot.deleteMany({});
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  it("populates referenced shots on the session document", async () => {
+    const baseSession = await Session.create({ userId });
+
+    const shot = await Shot.create({
+      score: 9,
+      sessionId: baseSession._id,
+      userId,
+    });
+
+    baseSession.shots.push(shot._id);
+    await baseSession.save();
+
+    const session = await Session.findById(baseSession._id);
+
+    const populatedSession = await session.populateShots();
+
+    expect(populatedSession).toBe(session);
+    expect(populatedSession.shots).toHaveLength(1);
+    expect(populatedSession.shots[0]._id.toString()).toBe(shot._id.toString());
+    expect(populatedSession.shots[0].score).toBe(9);
+  });
+});

--- a/model/session.js
+++ b/model/session.js
@@ -33,8 +33,9 @@ const sessionSchema = new mongoose.Schema({
 });
 
 // Method to populate shot details when retrieving session
-sessionSchema.methods.populateShots = function () {
-    return this.populate('shots').execPopulate();
+sessionSchema.methods.populateShots = async function () {
+    await this.populate('shots');
+    return this;
 };
 
 // Export as default


### PR DESCRIPTION
## Summary
- update the Session model's populateShots helper to use the async populate API and return the hydrated document
- add a Session model test ensuring populateShots populates referenced shots

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9e7c81dd8832aaedb269273b05c24