### PR TITLE
Ensure session fetch honors user ownership

### DIFF
--- a/controller/sessionController.js
+++ b/controller/sessionController.js
@@ -1,125 +1,4 @@
-import Shot from '../model/shot.js';
 import Session from '../model/session.js';
-
-// Add a new shot
-export const addShot = async (req, res) => {
-  try {
-    const shot = new Shot({ 
-      ...req.body, 
-      sessionId: req.params.sessionId,
-      positionX: req.body.positionX || 0, // Default value for positionX
-      positionY: req.body.positionY || 0, // Default value for positionY
-      timestamp: new Date() // Automatically set timestamp
-    });
-    await shot.save();
-
-    // Add the shot's ID to the session's shots array
-    const session = await Session.findById(req.params.sessionId);
-    if (!session) {
-      return res.status(404).json({ error: 'Session not found' });
-    }
-    session.shots.push(shot._id);
-
-    // Update session statistics
-    session.totalShots += 1;
-    session.maxScore = Math.max(session.maxScore, shot.score);
-    session.minScore = session.minScore === 0 ? shot.score : Math.min(session.minScore, shot.score);
-    session.averageScore = ((session.averageScore * (session.totalShots - 1)) + shot.score) / session.totalShots;
-
-    await session.save();
-
-    res.status(201).json(shot);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// Get all shots by session ID
-export const getShotsBySession = async (req, res) => {
-  try {
-    const shots = await Shot.find({ sessionId: req.params.sessionId });
-    res.json(shots);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// Get a shot by ID
-export const getShotById = async (req, res) => {
-  try {
-    const shot = await Shot.findById(req.params.shotId);
-    if (!shot) {
-      return res.status(404).json({ error: 'Shot not found' });
-    }
-    res.json(shot);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// Update a shot by ID
-export const updateShot = async (req, res) => {
-  try {
-    const shot = await Shot.findByIdAndUpdate(
-      req.params.shotId,
-      { 
-        ...req.body,
-        positionX: req.body.positionX || 0, // Default value for positionX
-        positionY: req.body.positionY || 0  // Default value for positionY
-      },
-      {
-        new: true,
-        runValidators: true,
-      }
-    );
-    if (!shot) {
-      return res.status(404).json({ error: 'Shot not found' });
-    }
-
-    // Update session statistics after shot update
-    const session = await Session.findById(shot.sessionId).populate('shots');
-    if (session) {
-      session.totalShots = session.shots.length;
-      session.maxScore = Math.max(...session.shots.map(s => s.score));
-      session.minScore = Math.min(...session.shots.map(s => s.score));
-      session.averageScore = session.shots.reduce((acc, s) => acc + s.score, 0) / session.totalShots;
-      await session.save();
-    }
-
-    res.json(shot);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// Delete a shot by ID
-export const deleteShot = async (req, res) => {
-  try {
-    const shot = await Shot.findByIdAndDelete(req.params.shotId);
-    if (!shot) {
-      return res.status(404).json({ error: 'Shot not found' });
-    }
-
-    // Remove the shot reference from the session's shots array and update statistics
-    const session = await Session.findByIdAndUpdate(shot.sessionId, { $pull: { shots: req.params.shotId } });
-    if (session) {
-      // Recalculate session statistics
-      const updatedSession = await Session.findById(shot.sessionId).populate('shots');
-      updatedSession.totalShots = updatedSession.shots.length;
-      updatedSession.maxScore = updatedSession.shots.length ? Math.max(...updatedSession.shots.map(s => s.score)) : 0;
-      updatedSession.minScore = updatedSession.shots.length ? Math.min(...updatedSession.shots.map(s => s.score)) : 0;
-      updatedSession.averageScore = updatedSession.shots.length 
-        ? updatedSession.shots.reduce((acc, s) => acc + s.score, 0) / updatedSession.totalShots 
-        : 0;
-
-      await updatedSession.save();
-    }
-
-    res.json({ message: 'Shot deleted successfully' });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
 
 // Add a new session
 export const addSession = async (req, res) => {
@@ -148,7 +27,10 @@ export const getSessions = async (req, res) => {
 export const getSessionById = async (req, res) => {
   try {
     const { userId, sessionId } = req.params;
-    const session = await Session.findOne({ _id: sessionId, userId }).populate('shots');
+    const session = await Session.findOne({ _id: sessionId, userId }).populate({
+      path: 'shots',
+      match: { userId },
+    });
     if (!session) {
       return res.status(404).json({ error: 'Session not found' });
     }
@@ -188,20 +70,6 @@ export const deleteSession = async (req, res) => {
       return res.status(404).json({ error: 'Session not found' });
     }
     res.json({ message: 'Session deleted successfully' });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// New function to populate shots in sessions
-export const populateShots = async (req, res) => {
-  try {
-    const { sessionId } = req.params;
-    const session = await Session.findById(sessionId).populate('shots');
-    if (!session) {
-      return res.status(404).json({ error: 'Session not found' });
-    }
-    res.json(session);
   } catch (error) {
     res.status(500).json({ error: error.message });
   }

--- a/model/session.js
+++ b/model/session.js
@@ -32,10 +32,5 @@ const sessionSchema = new mongoose.Schema({
     }
 });
 
-// Method to populate shot details when retrieving session
-sessionSchema.methods.populateShots = function () {
-    return this.populate('shots').execPopulate();
-};
-
 // Export as default
 export default mongoose.model('Session', sessionSchema);

--- a/route/sessionRoutes.js
+++ b/route/sessionRoutes.js
@@ -6,8 +6,7 @@ import {
   getSessions,
   getSessionById,
   updateSession,
-  deleteSession,
-  populateShots
+  deleteSession
 } from '../controller/sessionController.js';
 
 // Importing Shot controller
@@ -29,7 +28,7 @@ router.get('/', getSessions);
 
 // Route to get a session by its ID for a specific user
 // @route GET /pistol/users/:userId/sessions/:sessionId
-router.get('/:sessionId', populateShots, getSessionById);
+router.get('/:sessionId', getSessionById);
 
 // Route to update a session by its ID for a specific user
 // @route PUT /pistol/users/:userId/sessions/:sessionId


### PR DESCRIPTION
## Summary
- simplify the session controller to focus on session CRUD and filter populated shots by the requesting user
- drop the populateShots middleware in favor of getSessionById and remove the unused schema helper

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9c455e7c0832aa81c62f19d11265d