### PR TITLE
Persist target metadata on shots

### DIFF
--- a/model/shot.js
+++ b/model/shot.js
@@ -17,6 +17,26 @@ const shotSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+  targetIndex: {
+    type: Number,
+    min: 0,
+    default: null,
+  },
+  targetNumber: {
+    type: Number,
+    min: 0,
+    default: null,
+  },
+  targetShotIndex: {
+    type: Number,
+    min: 0,
+    default: null,
+  },
+  targetShotNumber: {
+    type: Number,
+    min: 0,
+    default: null,
+  },
   sessionId: {
     type: mongoose.Schema.Types.ObjectId,
     ref: 'Session',

--- a/route/shotRoutes.js
+++ b/route/shotRoutes.js
@@ -52,6 +52,21 @@ router.post(
       min: 0,
       max: 10,
     }),
+    check("targetIndex", "targetIndex must be a non-negative integer")
+      .optional({ nullable: true })
+      .isInt({ min: 0 }),
+    check("targetNumber", "targetNumber must be a non-negative integer")
+      .optional({ nullable: true })
+      .isInt({ min: 0 }),
+    check("targetShotIndex", "targetShotIndex must be a non-negative integer")
+      .optional({ nullable: true })
+      .isInt({ min: 0 }),
+    check(
+      "targetShotNumber",
+      "targetShotNumber must be a non-negative integer",
+    )
+      .optional({ nullable: true })
+      .isInt({ min: 0 }),
   ],
   (req, res, next) => {
     const errors = validationResult(req);
@@ -106,6 +121,21 @@ router.put(
     check("score", "Score must be between 0 and 10")
       .optional()
       .isFloat({ min: 0, max: 10 }),
+    check("targetIndex", "targetIndex must be a non-negative integer")
+      .optional({ nullable: true })
+      .isInt({ min: 0 }),
+    check("targetNumber", "targetNumber must be a non-negative integer")
+      .optional({ nullable: true })
+      .isInt({ min: 0 }),
+    check("targetShotIndex", "targetShotIndex must be a non-negative integer")
+      .optional({ nullable: true })
+      .isInt({ min: 0 }),
+    check(
+      "targetShotNumber",
+      "targetShotNumber must be a non-negative integer",
+    )
+      .optional({ nullable: true })
+      .isInt({ min: 0 }),
   ],
   (req, res, next) => {
     const errors = validationResult(req);

--- a/util/shotMetadata.js
+++ b/util/shotMetadata.js
@@ -1,0 +1,38 @@
+export const normalizeTargetMetadata = (payload = {}) => {
+  if (!payload || typeof payload !== "object") {
+    return {};
+  }
+
+  const normalized = { ...payload };
+
+  const aliasGroups = {
+    targetIndex: ["targetIndex", "target_index"],
+    targetNumber: [
+      "targetNumber",
+      "target_number",
+      "targetNo",
+      "target_no",
+    ],
+    targetShotIndex: ["targetShotIndex", "target_shot_index"],
+    targetShotNumber: [
+      "targetShotNumber",
+      "target_shot_number",
+      "targetShotNo",
+      "target_shot_no",
+    ],
+  };
+
+  for (const [canonical, aliases] of Object.entries(aliasGroups)) {
+    for (const alias of aliases) {
+      if (Object.prototype.hasOwnProperty.call(payload, alias)) {
+        normalized[canonical] = payload[alias];
+        if (alias !== canonical) {
+          delete normalized[alias];
+        }
+        break;
+      }
+    }
+  }
+
+  return normalized;
+};


### PR DESCRIPTION
## Summary
- persist per-target metadata on shots by extending the schema and controllers
- normalize incoming shot payloads so camelCase and snake_case target keys are stored consistently
- validate and test the new metadata handling to ensure the API returns the target grouping data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc7af16b34832aaf93260afba2b10f