### PR TITLE
Refactor sessions to group shots by targets

### DIFF
--- a/controller/sessionController.js
+++ b/controller/sessionController.js
@@ -1,144 +1,12 @@
 import Shot from '../model/shot.js';
 import Session from '../model/session.js';
-import { normalizeTargetMetadata } from '../util/shotMetadata.js';
-
-// Add a new shot
-export const addShot = async (req, res) => {
-  try {
-    const normalizedBody = normalizeTargetMetadata(req.body);
-    const { positionX, positionY, timestamp, ...shotData } = normalizedBody;
-
-    const shot = new Shot({
-      ...shotData,
-      sessionId: req.params.sessionId,
-      positionX: positionX ?? 0, // Default value for positionX
-      positionY: positionY ?? 0, // Default value for positionY
-      ...(timestamp !== undefined ? { timestamp } : { timestamp: new Date() })
-    });
-    await shot.save();
-
-    // Add the shot's ID to the session's shots array
-    const session = await Session.findById(req.params.sessionId);
-    if (!session) {
-      return res.status(404).json({ error: 'Session not found' });
-    }
-    session.shots.push(shot._id);
-
-    // Update session statistics
-    session.totalShots += 1;
-    session.maxScore = Math.max(session.maxScore, shot.score);
-    session.minScore = session.minScore === 0 ? shot.score : Math.min(session.minScore, shot.score);
-    session.averageScore = ((session.averageScore * (session.totalShots - 1)) + shot.score) / session.totalShots;
-
-    await session.save();
-
-    res.status(201).json(shot);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// Get all shots by session ID
-export const getShotsBySession = async (req, res) => {
-  try {
-    const shots = await Shot.find({ sessionId: req.params.sessionId });
-    res.json(shots);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// Get a shot by ID
-export const getShotById = async (req, res) => {
-  try {
-    const shot = await Shot.findById(req.params.shotId);
-    if (!shot) {
-      return res.status(404).json({ error: 'Shot not found' });
-    }
-    res.json(shot);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// Update a shot by ID
-export const updateShot = async (req, res) => {
-  try {
-    const normalizedBody = normalizeTargetMetadata(req.body);
-    const { positionX, positionY, timestamp, ...updateData } = normalizedBody;
-
-    if (positionX !== undefined) {
-      updateData.positionX = positionX;
-    }
-    if (positionY !== undefined) {
-      updateData.positionY = positionY;
-    }
-    if (timestamp !== undefined) {
-      updateData.timestamp = timestamp;
-    }
-
-    const shot = await Shot.findByIdAndUpdate(
-      req.params.shotId,
-      updateData,
-      {
-        new: true,
-        runValidators: true,
-      }
-    );
-    if (!shot) {
-      return res.status(404).json({ error: 'Shot not found' });
-    }
-
-    // Update session statistics after shot update
-    const session = await Session.findById(shot.sessionId).populate('shots');
-    if (session) {
-      session.totalShots = session.shots.length;
-      session.maxScore = Math.max(...session.shots.map(s => s.score));
-      session.minScore = Math.min(...session.shots.map(s => s.score));
-      session.averageScore = session.shots.reduce((acc, s) => acc + s.score, 0) / session.totalShots;
-      await session.save();
-    }
-
-    res.json(shot);
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
-
-// Delete a shot by ID
-export const deleteShot = async (req, res) => {
-  try {
-    const shot = await Shot.findByIdAndDelete(req.params.shotId);
-    if (!shot) {
-      return res.status(404).json({ error: 'Shot not found' });
-    }
-
-    // Remove the shot reference from the session's shots array and update statistics
-    const session = await Session.findByIdAndUpdate(shot.sessionId, { $pull: { shots: req.params.shotId } });
-    if (session) {
-      // Recalculate session statistics
-      const updatedSession = await Session.findById(shot.sessionId).populate('shots');
-      updatedSession.totalShots = updatedSession.shots.length;
-      updatedSession.maxScore = updatedSession.shots.length ? Math.max(...updatedSession.shots.map(s => s.score)) : 0;
-      updatedSession.minScore = updatedSession.shots.length ? Math.min(...updatedSession.shots.map(s => s.score)) : 0;
-      updatedSession.averageScore = updatedSession.shots.length 
-        ? updatedSession.shots.reduce((acc, s) => acc + s.score, 0) / updatedSession.totalShots 
-        : 0;
-
-      await updatedSession.save();
-    }
-
-    res.json({ message: 'Shot deleted successfully' });
-  } catch (error) {
-    res.status(500).json({ error: error.message });
-  }
-};
+import Target from '../model/target.js';
 
 // Add a new session
 export const addSession = async (req, res) => {
   try {
     const { userId } = req.params;
-    const session = new Session({ ...req.body, userId }); // Associate session with userId
+    const session = new Session({ ...req.body, userId });
     await session.save();
     res.status(201).json(session);
   } catch (error) {
@@ -150,21 +18,25 @@ export const addSession = async (req, res) => {
 export const getSessions = async (req, res) => {
   try {
     const { userId } = req.params;
-    const sessions = await Session.find({ userId }); // Filter by userId
+    const sessions = await Session.find({ userId });
     res.json(sessions);
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
 };
 
-// Get a session by ID for a specific user
+// Get a session by ID for a specific user, including targets and shots
 export const getSessionById = async (req, res) => {
   try {
     const { userId, sessionId } = req.params;
-    const session = await Session.findOne({ _id: sessionId, userId }).populate('shots');
+    const session = await Session.findOne({ _id: sessionId, userId });
+
     if (!session) {
       return res.status(404).json({ error: 'Session not found' });
     }
+
+    await session.populateTargets();
+
     res.json(session);
   } catch (error) {
     res.status(500).json({ error: error.message });
@@ -183,9 +55,11 @@ export const updateSession = async (req, res) => {
         runValidators: true,
       }
     );
+
     if (!session) {
       return res.status(404).json({ error: 'Session not found' });
     }
+
     res.json(session);
   } catch (error) {
     res.status(500).json({ error: error.message });
@@ -197,9 +71,14 @@ export const deleteSession = async (req, res) => {
   try {
     const { userId, sessionId } = req.params;
     const session = await Session.findOneAndDelete({ _id: sessionId, userId });
+
     if (!session) {
       return res.status(404).json({ error: 'Session not found' });
     }
+
+    await Target.deleteMany({ sessionId: session._id });
+    await Shot.deleteMany({ sessionId: session._id });
+
     res.json({ message: 'Session deleted successfully' });
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/model/session.js
+++ b/model/session.js
@@ -21,10 +21,15 @@ const sessionSchema = new mongoose.Schema({
         type: Number,
         default: 0,
     },
-    shots: [{
-        type: mongoose.Schema.Types.ObjectId,
-        ref: 'Shot'
-    }],
+    targets: {
+        type: [
+            {
+                type: mongoose.Schema.Types.ObjectId,
+                ref: 'Target',
+            },
+        ],
+        default: [],
+    },
     userId: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'User',
@@ -32,9 +37,16 @@ const sessionSchema = new mongoose.Schema({
     }
 });
 
-// Method to populate shot details when retrieving session
-sessionSchema.methods.populateShots = async function () {
-    await this.populate('shots');
+// Method to populate target and shot details when retrieving session
+sessionSchema.methods.populateTargets = async function () {
+    await this.populate({
+        path: 'targets',
+        options: { sort: { targetNumber: 1 } },
+        populate: {
+            path: 'shots',
+            options: { sort: { timestamp: 1 } },
+        },
+    });
     return this;
 };
 

--- a/model/shot.js
+++ b/model/shot.js
@@ -17,6 +17,11 @@ const shotSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+  targetId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Target',
+    required: true,
+  },
   targetIndex: {
     type: Number,
     min: 0,

--- a/model/target.js
+++ b/model/target.js
@@ -1,0 +1,37 @@
+import mongoose from 'mongoose';
+
+const targetSchema = new mongoose.Schema(
+  {
+    targetNumber: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+    sessionId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Session',
+      required: true,
+    },
+    userId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+    },
+    shots: [
+      {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'Shot',
+      },
+    ],
+  },
+  {
+    timestamps: true,
+  },
+);
+
+targetSchema.index(
+  { sessionId: 1, userId: 1, targetNumber: 1 },
+  { unique: true },
+);
+
+export default mongoose.model('Target', targetSchema);

--- a/route/shotRoutes.js
+++ b/route/shotRoutes.js
@@ -11,6 +11,25 @@ import Shot from "../model/shot.js"; // Correct import of Shot model
 import { check, validationResult } from "express-validator";
 import mongoose from "mongoose"; // Import for ObjectId validation
 
+const hasTargetNumberInput = (body = {}) => {
+  const targetNumberKeys = [
+    "targetNumber",
+    "target_number",
+    "targetNo",
+    "target_no",
+  ];
+  const targetIndexKeys = ["targetIndex", "target_index"];
+
+  return (
+    targetNumberKeys.some(
+      (key) => body[key] !== undefined && body[key] !== null,
+    ) ||
+    targetIndexKeys.some(
+      (key) => body[key] !== undefined && body[key] !== null,
+    )
+  );
+};
+
 // Middleware to validate ObjectId
 const validateObjectId = (paramName) => {
   return (req, res, next) => {
@@ -69,6 +88,12 @@ router.post(
       .isInt({ min: 0 }),
   ],
   (req, res, next) => {
+    if (!hasTargetNumberInput(req.body)) {
+      return res
+        .status(400)
+        .json({ error: "targetNumber is required to add a shot" });
+    }
+
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });

--- a/util/shotMetadata.js
+++ b/util/shotMetadata.js
@@ -34,5 +34,12 @@ export const normalizeTargetMetadata = (payload = {}) => {
     }
   }
 
+  if (
+    !Object.prototype.hasOwnProperty.call(normalized, "targetNumber") &&
+    Object.prototype.hasOwnProperty.call(normalized, "targetIndex")
+  ) {
+    normalized.targetNumber = normalized.targetIndex;
+  }
+
   return normalized;
 };


### PR DESCRIPTION
## Summary
- introduce a Target schema and update Session/Shot models to store sessions as target collections
- rework shot controller logic and API routes to create targets, group results by target, and clean up empty targets
- normalize target metadata aliases and extend tests for the new session > target > shot hierarchy

## Testing
- npm test
- npm test -- --runTestsByPath controller/__tests__/shotController.test.js model/__tests__/sessionModel.test.js --silent

------
https://chatgpt.com/codex/tasks/task_e_68cc823645c4832ab6aea5504a59f967