### PR TITLE
Restore compatibility with legacy shot endpoints

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import dotenv from "dotenv";
 import connectDB from "./util/db.js";
 import sessionRoutes from "./route/sessionRoutes.js";
 import userRoutes from "./route/userRoutes.js";
+import legacyShotRoutes from "./route/legacyShotRoutes.js";
 import path from "path";
 import { fileURLToPath } from "url";
 import { dirname } from "path";
@@ -101,6 +102,10 @@ app.use("/pistol/users", userRoutes); // Base route for users
 
 // Nested session and shot routes to include userId
 app.use("/pistol/users/:userId/sessions", sessionRoutes);
+
+// Backward-compatible routes for clients that have not adopted the nested
+// userId structure yet. These endpoints infer the userId from the session.
+app.use("/pistol/sessions", legacyShotRoutes);
 
 // Handle 404 errors (not found routes)
 app.use((req, res, next) => {

--- a/route/__tests__/legacyShotRoutes.test.js
+++ b/route/__tests__/legacyShotRoutes.test.js
@@ -1,0 +1,83 @@
+import express from "express";
+import mongoose from "mongoose";
+import request from "supertest";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+
+import sessionRoutes from "../sessionRoutes.js";
+import legacyShotRoutes from "../legacyShotRoutes.js";
+import User from "../../model/user.js";
+import Session from "../../model/session.js";
+import Shot from "../../model/shot.js";
+import Target from "../../model/target.js";
+
+describe("Legacy shot routes", () => {
+  let app;
+  let mongoServer;
+  let user;
+  let session;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+
+    app = express();
+    app.use(express.json());
+    app.use("/pistol/users/:userId/sessions", sessionRoutes);
+    app.use("/pistol/sessions", legacyShotRoutes);
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      Shot.deleteMany({}),
+      Target.deleteMany({}),
+      Session.deleteMany({}),
+      User.deleteMany({}),
+    ]);
+
+    user = await User.create({ username: "legacy-user" });
+    session = await Session.create({ userId: user._id });
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  it("adds a shot using the legacy endpoint by inferring the userId", async () => {
+    const res = await request(app)
+      .post(`/pistol/sessions/${session._id.toString()}/shots`)
+      .send({ score: 9.4, targetNumber: 0 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.userId).toBe(user._id.toString());
+    expect(res.body.sessionId).toBe(session._id.toString());
+
+    const shotInDb = await Shot.findById(res.body._id);
+    expect(shotInDb).not.toBeNull();
+    expect(shotInDb.userId.toString()).toBe(user._id.toString());
+  });
+
+  it("retrieves shots using the legacy endpoint", async () => {
+    await request(app)
+      .post(`/pistol/sessions/${session._id.toString()}/shots`)
+      .send({ score: 8.7, targetNumber: 1 });
+
+    const res = await request(app).get(
+      `/pistol/sessions/${session._id.toString()}/shots`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].targetNumber).toBe(1);
+    expect(res.body[0].shots).toHaveLength(1);
+    expect(res.body[0].shots[0].userId).toBe(user._id.toString());
+  });
+});

--- a/route/legacyShotRoutes.js
+++ b/route/legacyShotRoutes.js
@@ -1,0 +1,65 @@
+import express from "express";
+import mongoose from "mongoose";
+
+import {
+  addShot,
+  getShotsBySession,
+  getShotById,
+  updateShot,
+  deleteShot,
+} from "../controller/shotController.js";
+import Session from "../model/session.js";
+
+const router = express.Router();
+
+const ensureUserIdFromSession = async (req, res, next) => {
+  if (req.params.userId) {
+    return next();
+  }
+
+  const { sessionId } = req.params;
+
+  if (!sessionId) {
+    return res.status(400).json({ error: "Session ID is required" });
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(sessionId)) {
+    return res.status(400).json({ error: "Invalid session identifier" });
+  }
+
+  try {
+    const session = await Session.findById(sessionId).select("userId");
+
+    if (!session) {
+      return res.status(404).json({ error: "Session not found" });
+    }
+
+    req.params.userId = session.userId.toString();
+    return next();
+  } catch (error) {
+    console.error("Failed to resolve user for legacy shot route:", error);
+    return res
+      .status(500)
+      .json({ error: "Failed to resolve user for legacy shot route" });
+  }
+};
+
+router.post("/:sessionId/shots", ensureUserIdFromSession, addShot);
+router.get("/:sessionId/shots", ensureUserIdFromSession, getShotsBySession);
+router.get(
+  "/:sessionId/shots/:shotId",
+  ensureUserIdFromSession,
+  getShotById,
+);
+router.put(
+  "/:sessionId/shots/:shotId",
+  ensureUserIdFromSession,
+  updateShot,
+);
+router.delete(
+  "/:sessionId/shots/:shotId",
+  ensureUserIdFromSession,
+  deleteShot,
+);
+
+export default router;


### PR DESCRIPTION
## Summary
- add a legacy router that infers the userId from a session so old /pistol/sessions routes keep working
- mount the compatibility router alongside the existing nested /pistol/users/:userId/sessions endpoints
- cover the legacy behaviour with route-level tests to ensure backwards compatibility

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd74361980832a8be83de6d25984fa