### PR TITLE
Add target controller endpoints and tests

### DIFF
--- a/controller/targetController.js
+++ b/controller/targetController.js
@@ -1,0 +1,258 @@
+import mongoose from "mongoose";
+import Target from "../model/target.js";
+import Session from "../model/session.js";
+import Shot from "../model/shot.js";
+import { recalculateSessionStats } from "../util/sessionStats.js";
+
+const parseTargetNumber = (value) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    return Number.NaN;
+  }
+
+  return parsed;
+};
+
+const validateOwnership = async ({ sessionId, userId }) => {
+  const session = await Session.findById(sessionId);
+
+  if (!session) {
+    return { status: 404, error: "Session not found" };
+  }
+
+  if (session.userId.toString() !== userId.toString()) {
+    return { status: 403, error: "Unauthorized to manage targets for this session" };
+  }
+
+  return { session };
+};
+
+export const createTarget = async (req, res) => {
+  try {
+    const { sessionId, userId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(sessionId) || !mongoose.Types.ObjectId.isValid(userId)) {
+      return res.status(400).json({ error: "Invalid session or user identifier" });
+    }
+
+    const normalizedSessionId = new mongoose.Types.ObjectId(sessionId);
+    const normalizedUserId = new mongoose.Types.ObjectId(userId);
+
+    const targetNumber = parseTargetNumber(req.body?.targetNumber);
+    if (targetNumber === null || Number.isNaN(targetNumber)) {
+      return res
+        .status(400)
+        .json({ error: "targetNumber is required and must be a non-negative integer" });
+    }
+
+    const { status, error } = await validateOwnership({
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    });
+
+    if (error) {
+      return res.status(status).json({ error });
+    }
+
+    const existingTarget = await Target.findOne({
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+      targetNumber,
+    });
+
+    if (existingTarget) {
+      return res
+        .status(409)
+        .json({ error: "A target with this targetNumber already exists for the session" });
+    }
+
+    const target = await Target.create({
+      targetNumber,
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+      shots: [],
+    });
+
+    await Session.findByIdAndUpdate(normalizedSessionId, {
+      $addToSet: { targets: target._id },
+    });
+
+    return res.status(201).json(target);
+  } catch (error) {
+    console.error("Error creating target:", error.message);
+    return res.status(500).json({ error: error.message });
+  }
+};
+
+export const listTargets = async (req, res) => {
+  try {
+    const { sessionId, userId } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(sessionId) || !mongoose.Types.ObjectId.isValid(userId)) {
+      return res.status(400).json({ error: "Invalid session or user identifier" });
+    }
+
+    const normalizedSessionId = new mongoose.Types.ObjectId(sessionId);
+    const normalizedUserId = new mongoose.Types.ObjectId(userId);
+
+    const { status, error } = await validateOwnership({
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    });
+
+    if (error) {
+      return res.status(status).json({ error });
+    }
+
+    const targets = await Target.find({
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    })
+      .sort({ targetNumber: 1 })
+      .populate({
+        path: "shots",
+        options: { sort: { timestamp: 1 } },
+      });
+
+    return res.json(targets);
+  } catch (error) {
+    console.error("Error listing targets:", error.message);
+    return res.status(500).json({ error: error.message });
+  }
+};
+
+export const updateTarget = async (req, res) => {
+  try {
+    const { sessionId, userId, targetId } = req.params;
+
+    if (
+      !mongoose.Types.ObjectId.isValid(sessionId) ||
+      !mongoose.Types.ObjectId.isValid(userId) ||
+      !mongoose.Types.ObjectId.isValid(targetId)
+    ) {
+      return res.status(400).json({ error: "Invalid identifier provided" });
+    }
+
+    const normalizedSessionId = new mongoose.Types.ObjectId(sessionId);
+    const normalizedUserId = new mongoose.Types.ObjectId(userId);
+    const normalizedTargetId = new mongoose.Types.ObjectId(targetId);
+
+    const { status, error } = await validateOwnership({
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    });
+
+    if (error) {
+      return res.status(status).json({ error });
+    }
+
+    const target = await Target.findOne({
+      _id: normalizedTargetId,
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    });
+
+    if (!target) {
+      return res.status(404).json({ error: "Target not found" });
+    }
+
+    if (!Object.prototype.hasOwnProperty.call(req.body ?? {}, "targetNumber")) {
+      return res
+        .status(400)
+        .json({ error: "targetNumber is required to update a target" });
+    }
+
+    const nextTargetNumber = parseTargetNumber(req.body.targetNumber);
+
+    if (nextTargetNumber === null || Number.isNaN(nextTargetNumber)) {
+      return res
+        .status(400)
+        .json({ error: "targetNumber must be a non-negative integer" });
+    }
+
+    if (nextTargetNumber !== target.targetNumber) {
+      const conflict = await Target.findOne({
+        sessionId: normalizedSessionId,
+        userId: normalizedUserId,
+        targetNumber: nextTargetNumber,
+        _id: { $ne: target._id },
+      });
+
+      if (conflict) {
+        return res
+          .status(409)
+          .json({ error: "A target with this targetNumber already exists for the session" });
+      }
+
+      target.targetNumber = nextTargetNumber;
+      await Shot.updateMany(
+        { targetId: target._id },
+        { $set: { targetNumber: nextTargetNumber } },
+      );
+    }
+
+    await target.save();
+
+    return res.json(target);
+  } catch (error) {
+    console.error("Error updating target:", error.message);
+    return res.status(500).json({ error: error.message });
+  }
+};
+
+export const deleteTarget = async (req, res) => {
+  try {
+    const { sessionId, userId, targetId } = req.params;
+
+    if (
+      !mongoose.Types.ObjectId.isValid(sessionId) ||
+      !mongoose.Types.ObjectId.isValid(userId) ||
+      !mongoose.Types.ObjectId.isValid(targetId)
+    ) {
+      return res.status(400).json({ error: "Invalid identifier provided" });
+    }
+
+    const normalizedSessionId = new mongoose.Types.ObjectId(sessionId);
+    const normalizedUserId = new mongoose.Types.ObjectId(userId);
+    const normalizedTargetId = new mongoose.Types.ObjectId(targetId);
+
+    const { status, error } = await validateOwnership({
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    });
+
+    if (error) {
+      return res.status(status).json({ error });
+    }
+
+    const target = await Target.findOne({
+      _id: normalizedTargetId,
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    });
+
+    if (!target) {
+      return res.status(404).json({ error: "Target not found" });
+    }
+
+    await Shot.deleteMany({ targetId: target._id });
+
+    await Session.findByIdAndUpdate(normalizedSessionId, {
+      $pull: { targets: target._id },
+    });
+
+    await target.deleteOne();
+
+    await recalculateSessionStats(normalizedSessionId);
+
+    return res.json({ message: "Target deleted successfully" });
+  } catch (error) {
+    console.error("Error deleting target:", error.message);
+    return res.status(500).json({ error: error.message });
+  }
+};

--- a/route/__tests__/targetRoutes.test.js
+++ b/route/__tests__/targetRoutes.test.js
@@ -1,0 +1,174 @@
+import express from "express";
+import request from "supertest";
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "@jest/globals";
+
+import sessionRoutes from "../sessionRoutes.js";
+import User from "../../model/user.js";
+import Session from "../../model/session.js";
+import Target from "../../model/target.js";
+import Shot from "../../model/shot.js";
+
+describe("/targets routes", () => {
+  let app;
+  let mongoServer;
+  let user;
+  let session;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    await mongoose.connect(mongoServer.getUri());
+
+    app = express();
+    app.use(express.json());
+    app.use("/pistol/users/:userId/sessions", sessionRoutes);
+  });
+
+  beforeEach(async () => {
+    await Promise.all([
+      Shot.deleteMany({}),
+      Target.deleteMany({}),
+      Session.deleteMany({}),
+      User.deleteMany({}),
+    ]);
+
+    user = await User.create({ username: "target-user" });
+    session = await Session.create({ userId: user._id });
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  it("creates targets for a session", async () => {
+    const res = await request(app)
+      .post(
+        `/pistol/users/${user._id.toString()}/sessions/${session._id.toString()}/targets`,
+      )
+      .send({ targetNumber: 2 });
+
+    expect(res.status).toBe(201);
+    expect(res.body.targetNumber).toBe(2);
+
+    const sessionDoc = await Session.findById(session._id);
+    expect(sessionDoc.targets).toHaveLength(1);
+
+    const target = await Target.findById(res.body._id);
+    expect(target).not.toBeNull();
+  });
+
+  it("lists targets sorted by number", async () => {
+    const firstTarget = await Target.create({
+      targetNumber: 5,
+      sessionId: session._id,
+      userId: user._id,
+      shots: [],
+    });
+    const secondTarget = await Target.create({
+      targetNumber: 1,
+      sessionId: session._id,
+      userId: user._id,
+      shots: [],
+    });
+
+    session.targets.push(firstTarget._id, secondTarget._id);
+    await session.save();
+
+    const res = await request(app).get(
+      `/pistol/users/${user._id.toString()}/sessions/${session._id.toString()}/targets`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body[0].targetNumber).toBe(1);
+    expect(res.body[1].targetNumber).toBe(5);
+  });
+
+  it("updates targets and cascades to shots", async () => {
+    const target = await Target.create({
+      targetNumber: 3,
+      sessionId: session._id,
+      userId: user._id,
+      shots: [],
+    });
+
+    session.targets.push(target._id);
+    await session.save();
+
+    const shot = await Shot.create({
+      score: 8,
+      sessionId: session._id,
+      userId: user._id,
+      targetId: target._id,
+      targetNumber: 3,
+    });
+
+    target.shots.push(shot._id);
+    await target.save();
+
+    const res = await request(app)
+      .put(
+        `/pistol/users/${user._id.toString()}/sessions/${session._id.toString()}/targets/${target._id.toString()}`,
+      )
+      .send({ targetNumber: 4 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.targetNumber).toBe(4);
+
+    const updatedShot = await Shot.findById(shot._id);
+    expect(updatedShot.targetNumber).toBe(4);
+  });
+
+  it("deletes targets, removes references, and recalculates stats", async () => {
+    const target = await Target.create({
+      targetNumber: 6,
+      sessionId: session._id,
+      userId: user._id,
+      shots: [],
+    });
+
+    session.targets.push(target._id);
+    session.totalShots = 1;
+    session.averageScore = 9;
+    session.maxScore = 9;
+    session.minScore = 9;
+    await session.save();
+
+    const shot = await Shot.create({
+      score: 9,
+      sessionId: session._id,
+      userId: user._id,
+      targetId: target._id,
+      targetNumber: 6,
+    });
+
+    target.shots.push(shot._id);
+    await target.save();
+
+    const res = await request(app).delete(
+      `/pistol/users/${user._id.toString()}/sessions/${session._id.toString()}/targets/${target._id.toString()}`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ message: "Target deleted successfully" });
+
+    const sessionDoc = await Session.findById(session._id);
+    expect(sessionDoc.targets).toHaveLength(0);
+    expect(sessionDoc.totalShots).toBe(0);
+    expect(sessionDoc.averageScore).toBe(0);
+    expect(sessionDoc.maxScore).toBe(0);
+    expect(sessionDoc.minScore).toBe(0);
+
+    const remainingShots = await Shot.find({ sessionId: session._id });
+    expect(remainingShots).toHaveLength(0);
+  });
+});

--- a/route/sessionRoutes.js
+++ b/route/sessionRoutes.js
@@ -18,6 +18,13 @@ import {
   deleteShot
 } from '../controller/shotController.js';
 
+import {
+  createTarget,
+  listTargets,
+  updateTarget,
+  deleteTarget,
+} from '../controller/targetController.js';
+
 // Route to add a new session for a specific user
 // @route POST /pistol/users/:userId/sessions
 router.post('/', addSession);
@@ -37,6 +44,24 @@ router.put('/:sessionId', updateSession);
 // Route to delete a session by its ID for a specific user
 // @route DELETE /pistol/users/:userId/sessions/:sessionId
 router.delete('/:sessionId', deleteSession);
+
+// Routes for managing targets within a session for a specific user
+
+// Route to create a new target within a session for a specific user
+// @route POST /pistol/users/:userId/sessions/:sessionId/targets
+router.post('/:sessionId/targets', createTarget);
+
+// Route to list targets within a session for a specific user
+// @route GET /pistol/users/:userId/sessions/:sessionId/targets
+router.get('/:sessionId/targets', listTargets);
+
+// Route to update a target within a session for a specific user
+// @route PUT /pistol/users/:userId/sessions/:sessionId/targets/:targetId
+router.put('/:sessionId/targets/:targetId', updateTarget);
+
+// Route to delete a target within a session for a specific user
+// @route DELETE /pistol/users/:userId/sessions/:sessionId/targets/:targetId
+router.delete('/:sessionId/targets/:targetId', deleteTarget);
 
 // Routes for managing shots within a session for a specific user
 


### PR DESCRIPTION
## Summary
- add a dedicated target controller that validates ownership, enforces unique target numbers, and keeps session targets in sync when creating, updating, or deleting targets
- expose REST endpoints for managing targets within sessions alongside the existing shot handlers
- cover the new controller and route behaviors with in-memory MongoDB tests for the /targets workflows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cee58d9518832aac2420be669f3f01