### PR TITLE
Validate session route identifiers

### DIFF
--- a/controller/sessionController.js
+++ b/controller/sessionController.js
@@ -1,3 +1,5 @@
+import mongoose from 'mongoose';
+
 import Shot from '../model/shot.js';
 import Session from '../model/session.js';
 import Target from '../model/target.js';
@@ -16,8 +18,13 @@ export const addSession = async (req, res) => {
 
 // Get all sessions for a specific user
 export const getSessions = async (req, res) => {
+  const { userId } = req.params;
+
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ error: 'Invalid user ID' });
+  }
+
   try {
-    const { userId } = req.params;
     const sessions = await Session.find({ userId });
     res.json(sessions);
   } catch (error) {
@@ -27,8 +34,17 @@ export const getSessions = async (req, res) => {
 
 // Get a session by ID for a specific user, including targets and shots
 export const getSessionById = async (req, res) => {
+  const { userId, sessionId } = req.params;
+
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ error: 'Invalid user ID' });
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(sessionId)) {
+    return res.status(400).json({ error: 'Invalid session ID' });
+  }
+
   try {
-    const { userId, sessionId } = req.params;
     const session = await Session.findOne({ _id: sessionId, userId });
 
     if (!session) {
@@ -45,8 +61,17 @@ export const getSessionById = async (req, res) => {
 
 // Update a session by ID for a specific user
 export const updateSession = async (req, res) => {
+  const { userId, sessionId } = req.params;
+
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ error: 'Invalid user ID' });
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(sessionId)) {
+    return res.status(400).json({ error: 'Invalid session ID' });
+  }
+
   try {
-    const { userId, sessionId } = req.params;
     const session = await Session.findOneAndUpdate(
       { _id: sessionId, userId },
       req.body,
@@ -68,8 +93,17 @@ export const updateSession = async (req, res) => {
 
 // Delete a session by ID for a specific user
 export const deleteSession = async (req, res) => {
+  const { userId, sessionId } = req.params;
+
+  if (!mongoose.Types.ObjectId.isValid(userId)) {
+    return res.status(400).json({ error: 'Invalid user ID' });
+  }
+
+  if (!mongoose.Types.ObjectId.isValid(sessionId)) {
+    return res.status(400).json({ error: 'Invalid session ID' });
+  }
+
   try {
-    const { userId, sessionId } = req.params;
     const session = await Session.findOneAndDelete({ _id: sessionId, userId });
 
     if (!session) {

--- a/route/__tests__/sessionRoutes.test.js
+++ b/route/__tests__/sessionRoutes.test.js
@@ -18,7 +18,7 @@ import User from "../../model/user.js";
 
 jest.setTimeout(60000);
 
-describe("GET /pistol/users/:userId/sessions/:sessionId", () => {
+describe("Session routes", () => {
   let app;
   let mongoServer;
 
@@ -65,5 +65,54 @@ describe("GET /pistol/users/:userId/sessions/:sessionId", () => {
 
     expect(res.status).toBe(404);
     expect(res.body).toEqual({ error: "Session not found" });
+  });
+
+  it("returns 400 when listing sessions for an invalid user ID", async () => {
+    const res = await request(app).get("/pistol/users/not-a-valid-id/sessions");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid user ID" });
+  });
+
+  it("returns 400 when fetching a session with an invalid user ID", async () => {
+    const res = await request(app).get(
+      "/pistol/users/not-a-valid-id/sessions/also-invalid",
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid user ID" });
+  });
+
+  it("returns 400 when fetching a session with an invalid session ID", async () => {
+    const user = await User.create({ username: "mallory" });
+
+    const res = await request(app).get(
+      `/pistol/users/${user._id.toString()}/sessions/not-a-valid-id`,
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid session ID" });
+  });
+
+  it("returns 400 when updating a session with an invalid session ID", async () => {
+    const user = await User.create({ username: "trent" });
+
+    const res = await request(app)
+      .put(`/pistol/users/${user._id.toString()}/sessions/not-a-valid-id`)
+      .send({ name: "irrelevant" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid session ID" });
+  });
+
+  it("returns 400 when deleting a session with an invalid session ID", async () => {
+    const user = await User.create({ username: "victor" });
+
+    const res = await request(app).delete(
+      `/pistol/users/${user._id.toString()}/sessions/not-a-valid-id`,
+    );
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: "Invalid session ID" });
   });
 });


### PR DESCRIPTION
## Summary
- guard session controller handlers with ObjectId validation and return 400 on invalid identifiers
- expand session route tests to cover invalid ID scenarios and expect 400 responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ceebce20c4832a9f9db5a9d6ba2d00