### PR TITLE
Resequence target numbering after updates

### DIFF
--- a/controller/__tests__/shotController.test.js
+++ b/controller/__tests__/shotController.test.js
@@ -409,7 +409,7 @@ describe("shotController session statistics", () => {
 
     const updatedShot = await Shot.findById(shot._id);
     expect(updatedShot.targetIndex).toBe(updateMetadata.targetIndex);
-    expect(updatedShot.targetNumber).toBe(updateMetadata.targetNumber);
+    expect(updatedShot.targetNumber).toBe(1);
     expect(updatedShot.targetShotIndex).toBe(updateMetadata.targetShotIndex);
     expect(updatedShot.targetShotNumber).toBe(updateMetadata.targetShotNumber);
 
@@ -417,13 +417,13 @@ describe("shotController session statistics", () => {
       .sort({ targetNumber: 1 })
       .lean();
     expect(targets).toHaveLength(1);
-    expect(targets[0].targetNumber).toBe(updateMetadata.targetNumber);
+    expect(targets[0].targetNumber).toBe(1);
     expect(targets[0].shots).toHaveLength(1);
     expect(targets[0].shots[0].toString()).toBe(updatedShot._id.toString());
     expect(updatedShot.targetId.toString()).toBe(targets[0]._id.toString());
 
     expect(updateRes.body.targetIndex).toBe(updateMetadata.targetIndex);
-    expect(updateRes.body.targetNumber).toBe(updateMetadata.targetNumber);
+    expect(updateRes.body.targetNumber).toBe(1);
     expect(updateRes.body.targetShotIndex).toBe(updateMetadata.targetShotIndex);
     expect(updateRes.body.targetShotNumber).toBe(updateMetadata.targetShotNumber);
   });
@@ -477,7 +477,7 @@ describe("shotController session statistics", () => {
       targetNumber: 1,
     });
     expect(remainingTargets).toHaveLength(1);
-    expect(remainingTargets[0].targetNumber).toBe(2);
+    expect(remainingTargets[0].targetNumber).toBe(1);
 
     const deleteResSecond = createMockResponse();
     await deleteShot(

--- a/util/targetSequence.js
+++ b/util/targetSequence.js
@@ -1,0 +1,75 @@
+import mongoose from "mongoose";
+import Target from "../model/target.js";
+import Shot from "../model/shot.js";
+
+const toObjectId = (value) => {
+  if (!value) {
+    return null;
+  }
+
+  if (value instanceof mongoose.Types.ObjectId) {
+    return value;
+  }
+
+  if (typeof value === "string" && mongoose.Types.ObjectId.isValid(value)) {
+    return new mongoose.Types.ObjectId(value);
+  }
+
+  return null;
+};
+
+export const resequenceTargetsForSession = async ({
+  sessionId,
+  userId,
+  startingNumber = 1,
+} = {}) => {
+  const normalizedSessionId = toObjectId(sessionId);
+  const normalizedUserId = toObjectId(userId);
+
+  if (!normalizedSessionId || !normalizedUserId) {
+    return;
+  }
+
+  const targets = await Target.find({
+    sessionId: normalizedSessionId,
+    userId: normalizedUserId,
+  })
+    .sort({ targetNumber: 1, createdAt: 1, _id: 1 })
+    .select({ _id: 1, targetNumber: 1 });
+
+  const updates = [];
+
+  let nextNumber = startingNumber;
+
+  for (const target of targets) {
+    if (target.targetNumber !== nextNumber) {
+      updates.push({ id: target._id, targetNumber: nextNumber });
+    }
+
+    nextNumber += 1;
+  }
+
+  if (updates.length === 0) {
+    return;
+  }
+
+  const temporaryStart = startingNumber + targets.length;
+
+  for (const [index, update] of updates.entries()) {
+    await Target.updateOne(
+      { _id: update.id },
+      { $set: { targetNumber: temporaryStart + index } },
+    );
+  }
+
+  for (const update of updates) {
+    await Target.updateOne(
+      { _id: update.id },
+      { $set: { targetNumber: update.targetNumber } },
+    );
+    await Shot.updateMany(
+      { targetId: update.id },
+      { $set: { targetNumber: update.targetNumber } },
+    );
+  }
+};


### PR DESCRIPTION
## Summary
- add a resequenceTargetsForSession helper to normalize target numbering and update linked shots
- invoke resequencing after target updates, deletions, and cleanup paths so numbering stays continuous
- refresh controllers and route tests to cover the new resequencing behavior and shot metadata updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf18b7c264832a8065a41c35c369e4