### PR TITLE
Resequence target numbering when adding shots

### DIFF
--- a/controller/__tests__/targetController.test.js
+++ b/controller/__tests__/targetController.test.js
@@ -82,6 +82,45 @@ describe("targetController", () => {
     expect(updatedSession.targets[0].toString()).toBe(targets[0]._id.toString());
   });
 
+  it("resequences numbering when targets are created with skipped values", async () => {
+    const firstRes = createMockResponse();
+    await createTarget(
+      {
+        params: {
+          sessionId: session._id.toString(),
+          userId: userId.toString(),
+        },
+        body: { targetNumber: 5 },
+      },
+      firstRes,
+    );
+
+    expect(firstRes.status).toHaveBeenCalledWith(201);
+    expect(firstRes.body.targetNumber).toBe(1);
+
+    const secondRes = createMockResponse();
+    await createTarget(
+      {
+        params: {
+          sessionId: session._id.toString(),
+          userId: userId.toString(),
+        },
+        body: { targetNumber: 7 },
+      },
+      secondRes,
+    );
+
+    expect(secondRes.status).toHaveBeenCalledWith(201);
+    expect(secondRes.body.targetNumber).toBe(2);
+
+    const targets = await Target.find({ sessionId: session._id })
+      .sort({ targetNumber: 1 })
+      .lean();
+
+    expect(targets).toHaveLength(2);
+    expect(targets.map((target) => target.targetNumber)).toEqual([1, 2]);
+  });
+
   it("lists targets sorted by targetNumber with populated shots", async () => {
     const firstTarget = await Target.create({
       targetNumber: 2,

--- a/controller/targetController.js
+++ b/controller/targetController.js
@@ -83,7 +83,14 @@ export const createTarget = async (req, res) => {
       $addToSet: { targets: target._id },
     });
 
-    return res.status(201).json(target);
+    await resequenceTargetsForSession({
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    });
+
+    const resequencedTarget = await Target.findById(target._id);
+
+    return res.status(201).json(resequencedTarget ?? target);
   } catch (error) {
     console.error("Error creating target:", error.message);
     return res.status(500).json({ error: error.message });

--- a/route/__tests__/shotFormSubmission.test.js
+++ b/route/__tests__/shotFormSubmission.test.js
@@ -53,7 +53,7 @@ describe("Shot routes accept form submissions", () => {
 
     expect(res.status).toBe(201);
     expect(res.body.score).toBe(9.5);
-    expect(res.body.targetNumber).toBe(2);
+    expect(res.body.targetNumber).toBe(1);
 
     const shots = await Shot.find({ sessionId: session._id });
     expect(shots).toHaveLength(1);
@@ -61,7 +61,7 @@ describe("Shot routes accept form submissions", () => {
 
     const targets = await Target.find({ sessionId: session._id });
     expect(targets).toHaveLength(1);
-    expect(targets[0].targetNumber).toBe(2);
+    expect(targets[0].targetNumber).toBe(1);
     expect(targets[0].shots).toHaveLength(1);
   });
 });

--- a/route/__tests__/targetRoutes.test.js
+++ b/route/__tests__/targetRoutes.test.js
@@ -57,7 +57,7 @@ describe("/targets routes", () => {
       .send({ targetNumber: 2 });
 
     expect(res.status).toBe(201);
-    expect(res.body.targetNumber).toBe(2);
+    expect(res.body.targetNumber).toBe(1);
 
     const sessionDoc = await Session.findById(session._id);
     expect(sessionDoc.targets).toHaveLength(1);


### PR DESCRIPTION
## Summary
- resequence targets whenever new shots or targets are created so numbering stays contiguous
- ensure shots persist the resequenced target number returned by the backend
- adjust and extend automated tests to cover resequencing behaviour across controllers and routes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf21a0518c832aa0f3348a317e6e61