### PR TITLE
Resequence targets before returning session data

### DIFF
--- a/controller/sessionController.js
+++ b/controller/sessionController.js
@@ -3,6 +3,7 @@ import mongoose from 'mongoose';
 import Shot from '../model/shot.js';
 import Session from '../model/session.js';
 import Target from '../model/target.js';
+import { resequenceTargetsForSession } from '../util/targetSequence.js';
 
 // Add a new session
 export const addSession = async (req, res) => {
@@ -50,6 +51,11 @@ export const getSessionById = async (req, res) => {
     if (!session) {
       return res.status(404).json({ error: 'Session not found' });
     }
+
+    await resequenceTargetsForSession({
+      sessionId: session._id,
+      userId: session.userId,
+    });
 
     await session.populateTargets();
 

--- a/controller/targetController.js
+++ b/controller/targetController.js
@@ -117,6 +117,11 @@ export const listTargets = async (req, res) => {
       return res.status(status).json({ error });
     }
 
+    await resequenceTargetsForSession({
+      sessionId: normalizedSessionId,
+      userId: normalizedUserId,
+    });
+
     const targets = await Target.find({
       sessionId: normalizedSessionId,
       userId: normalizedUserId,

--- a/route/__tests__/sessionRoutes.test.js
+++ b/route/__tests__/sessionRoutes.test.js
@@ -63,7 +63,7 @@ describe("Session routes", () => {
     const session = await Session.create({ userId: user._id });
 
     const target = await Target.create({
-      targetNumber: 1,
+      targetNumber: 4,
       sessionId: session._id,
       userId: user._id,
       shots: [],
@@ -112,6 +112,74 @@ describe("Session routes", () => {
     expect(res.body.shots[0]).toEqual(populatedTarget.shots[0]);
     expect(res.body.shots[0]).not.toHaveProperty("__v");
     expect(res.body.shots[0]).not.toHaveProperty("_doc");
+
+    const resequencedShot = await Shot.findById(shot._id).lean();
+    expect(resequencedShot.targetNumber).toBe(1);
+  });
+
+  it("returns grouped shots with contiguous target numbering", async () => {
+    const user = await User.create({ username: "carol" });
+    const session = await Session.create({ userId: user._id });
+
+    const firstTarget = await Target.create({
+      targetNumber: 2,
+      sessionId: session._id,
+      userId: user._id,
+      shots: [],
+    });
+
+    const secondTarget = await Target.create({
+      targetNumber: 7,
+      sessionId: session._id,
+      userId: user._id,
+      shots: [],
+    });
+
+    session.targets.push(firstTarget._id, secondTarget._id);
+    await session.save();
+
+    const firstShot = await Shot.create({
+      score: 5,
+      sessionId: session._id,
+      userId: user._id,
+      targetId: firstTarget._id,
+      targetNumber: 2,
+    });
+
+    const secondShot = await Shot.create({
+      score: 9,
+      sessionId: session._id,
+      userId: user._id,
+      targetId: secondTarget._id,
+      targetNumber: 7,
+    });
+
+    firstTarget.shots.push(firstShot._id);
+    secondTarget.shots.push(secondShot._id);
+    await firstTarget.save();
+    await secondTarget.save();
+
+    const res = await request(app).get(
+      `/pistol/users/${user._id.toString()}/sessions/${session._id.toString()}/shots`,
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    expect(res.body.map((target) => target.targetNumber)).toEqual([1, 2]);
+    expect(res.body[0].shots).toHaveLength(1);
+    expect(res.body[0].shots[0].targetNumber).toBe(1);
+    expect(res.body[1].shots).toHaveLength(1);
+    expect(res.body[1].shots[0].targetNumber).toBe(2);
+
+    const resequencedTargets = await Target.find({ sessionId: session._id })
+      .sort({ targetNumber: 1 })
+      .lean();
+    expect(resequencedTargets.map((target) => target.targetNumber)).toEqual([1, 2]);
+
+    const resequencedShots = await Shot.find({ sessionId: session._id })
+      .sort({ targetNumber: 1, _id: 1 })
+      .lean();
+    expect(resequencedShots.map((shot) => shot.targetNumber)).toEqual([1, 2]);
   });
 
   it("returns 404 when the session does not belong to the requesting user", async () => {

--- a/route/__tests__/targetRoutes.test.js
+++ b/route/__tests__/targetRoutes.test.js
@@ -66,7 +66,7 @@ describe("/targets routes", () => {
     expect(target).not.toBeNull();
   });
 
-  it("lists targets sorted by number", async () => {
+  it("lists targets with contiguous numbering", async () => {
     const firstTarget = await Target.create({
       targetNumber: 5,
       sessionId: session._id,
@@ -74,7 +74,7 @@ describe("/targets routes", () => {
       shots: [],
     });
     const secondTarget = await Target.create({
-      targetNumber: 1,
+      targetNumber: 2,
       sessionId: session._id,
       userId: user._id,
       shots: [],
@@ -89,8 +89,12 @@ describe("/targets routes", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveLength(2);
-    expect(res.body[0].targetNumber).toBe(1);
-    expect(res.body[1].targetNumber).toBe(5);
+    expect(res.body.map((target) => target.targetNumber)).toEqual([1, 2]);
+
+    const resequencedTargets = await Target.find({ sessionId: session._id })
+      .sort({ targetNumber: 1 })
+      .lean();
+    expect(resequencedTargets.map((target) => target.targetNumber)).toEqual([1, 2]);
   });
 
   it("updates targets, cascades to shots, and resequences numbering", async () => {


### PR DESCRIPTION
## Summary
- resequence session targets whenever shot buckets are ensured and before serving grouped targets or shots
- resequence session targets when returning session details so clients always receive contiguous numbering
- expand controller and route tests to cover legacy misnumbered targets and contiguous numbering in responses

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2a0f43d4832ab1422b2b74e28259